### PR TITLE
Fix undefined method error for URI

### DIFF
--- a/lib/cheatset/creator.rb
+++ b/lib/cheatset/creator.rb
@@ -86,7 +86,7 @@ class Cheatset::Creator
                "index.html")
     
     @cheatsheet.categories.each do |category|
-      category_strip = URI.escape(category.id.strip).gsub(/\//, '%252F');
+      category_strip = URI.encode_www_form_component(category.id.strip).gsub(/\//, '%252F');
       if @cheatsheet.title != category.id
         db.execute(sql, category.id, 'Category',
                  "index.html\#//dash_ref/Category/#{category_strip}/1")
@@ -96,7 +96,7 @@ class Cheatset::Creator
         if entry.command && entry.command.length > 0
           first_command = entry.command.first
         end
-        href = (entry.name || entry.index_name) ? "index.html\#//dash_ref_#{category_strip}/Entry/#{URI.escape((entry.index_name) ? entry.index_name.strip : entry.tags_stripped_name.strip).gsub(/\//, '%252F')}/0" : (first_command) ? "index.html\#//dash_ref_#{category_strip}/Command/#{URI.escape(first_command).gsub(/\//, '%252F')}/0" : ""
+        href = (entry.name || entry.index_name) ? "index.html\#//dash_ref_#{category_strip}/Entry/#{URI.encode_www_form_component((entry.index_name) ? entry.index_name.strip : entry.tags_stripped_name.strip).gsub(/\//, '%252F')}/0" : (first_command) ? "index.html\#//dash_ref_#{category_strip}/Command/#{URI.escape(first_command).gsub(/\//, '%252F')}/0" : ""
         if entry.command
           entry.command.each do |command|
             if(!command.strip.empty? && !entry.not_in_main_index)


### PR DESCRIPTION
I've fixed 'undefined method URI.escape' that occurs at the generate command which causes invalid searching keywords for the cheatset file.